### PR TITLE
Update getting-started example to use new drive paradigm

### DIFF
--- a/getting-started/robot.py
+++ b/getting-started/robot.py
@@ -18,28 +18,25 @@ class MyRobot(wpilib.IterativeRobot):
         self.right_motor = wpilib.Spark(1)
         self.drive = wpilib.drive.DifferentialDrive(self.left_motor, self.right_motor)
         self.stick = wpilib.Joystick(1)
+        self.timer = wpilib.Timer()
 
     def autonomousInit(self):
         """This function is run once each time the robot enters autonomous mode."""
-        self.auto_loop_counter = 0
+        self.timer.reset()
+        self.timer.start()
 
     def autonomousPeriodic(self):
         """This function is called periodically during autonomous."""
 
-        # Check if we've completed 100 loops (approximately 2 seconds)
-        if self.auto_loop_counter < 100:
+        # Drive for two seconds
+        if self.timer.get() < 2.0:
             self.drive.arcadeDrive(-0.5, 0)  # Drive forwards at half speed
-            self.auto_loop_counter += 1
         else:
             self.drive.arcadeDrive(0, 0)  # Stop robot
 
     def teleopPeriodic(self):
         """This function is called periodically during operator control."""
         self.drive.arcadeDrive(self.stick.getY(), self.stick.getX())
-
-    def testPeriodic(self):
-        """This function is called periodically during test mode."""
-        pass
 
 
 if __name__ == "__main__":

--- a/getting-started/robot.py
+++ b/getting-started/robot.py
@@ -4,15 +4,19 @@
 """
 
 import wpilib
+import wpilib.drive
+
 
 class MyRobot(wpilib.IterativeRobot):
-    
+
     def robotInit(self):
         """
         This function is called upon program startup and
         should be used for any initialization code.
         """
-        self.robot_drive = wpilib.RobotDrive(0,1)
+        self.left_motor = wpilib.Spark(0)
+        self.right_motor = wpilib.Spark(1)
+        self.drive = wpilib.drive.DifferentialDrive(self.left_motor, self.right_motor)
         self.stick = wpilib.Joystick(1)
 
     def autonomousInit(self):
@@ -21,21 +25,22 @@ class MyRobot(wpilib.IterativeRobot):
 
     def autonomousPeriodic(self):
         """This function is called periodically during autonomous."""
-        
+
         # Check if we've completed 100 loops (approximately 2 seconds)
         if self.auto_loop_counter < 100:
-            self.robot_drive.drive(-0.5, 0) # Drive forwards at half speed
+            self.drive.arcadeDrive(-0.5, 0)  # Drive forwards at half speed
             self.auto_loop_counter += 1
         else:
-            self.robot_drive.drive(0, 0)    #Stop robot
+            self.drive.arcadeDrive(0, 0)  # Stop robot
 
     def teleopPeriodic(self):
         """This function is called periodically during operator control."""
-        self.robot_drive.arcadeDrive(self.stick)
+        self.drive.arcadeDrive(self.stick.getY(), self.stick.getX())
 
     def testPeriodic(self):
         """This function is called periodically during test mode."""
-        wpilib.LiveWindow.run()
+        pass
+
 
 if __name__ == "__main__":
     wpilib.run(MyRobot)


### PR DESCRIPTION
This removes the deprecated LiveWindow.run() usage, as per [this allwpilib example](https://github.com/wpilibsuite/allwpilib/blob/0ef9803363380c58804a0d885a7cc7ea8233a1ac/wpilibcExamples/src/main/cpp/examples/GearsBot/src/Robot.cpp), the new `arcadeDrive` syntax as per [this allwpilib example](https://github.com/wpilibsuite/allwpilib/blob/master/wpilibcExamples/src/main/cpp/examples/ArcadeDrive/src/Robot.cpp), and uses the new `DifferentialDrive` class instead of the deprecated `RobotDrive`.

Note that this removes parity with the ScreenSteps documentation, since it has not yet been updated for both C++ and Java. I've already sent an email about this.

I'm also just about finished with updating the drivetrain sections of the Anatomy of a Robot page from the Programmer's Guide.