### PR TITLE
Removed robot_drive from Auto.

### DIFF
--- a/physics/src/robot.py
+++ b/physics/src/robot.py
@@ -55,9 +55,9 @@ class MyRobot(wpilib.TimedRobot):
 
     def autonomousPeriodic(self):
         if self.timer.get() < 2.0:
-            self.robot_drive.arcadeDrive(-1.0, 0.3)
+            self.drive.arcadeDrive(-1.0, -0.3)
         else:
-            self.robot_drive.arcadeDrive(0, 0)
+            self.drive.arcadeDrive(0, 0)
 
     def teleopPeriodic(self):
         """Called when operation control mode is enabled"""


### PR DESCRIPTION
Hello,
Thank you for the work on the sim.  When I tried the auto, the simulator crashed because it could not find the robot_drive method.  So, I edited it to mimic that of teleop.  This new physics module is incredible.