### PR TITLE
Edited the mecanum drive example code to be more frc-docs like.

### DIFF
--- a/mecanum-drive/robot.py
+++ b/mecanum-drive/robot.py
@@ -30,14 +30,14 @@ class MyRobot(TimedRobot):
         self.frontRight.setInverted(True)
         self.rearRight.setInverted(True)
 
-        self.m_drive = MecanumDrive(self.frontLeft, self.rearLeft, self.frontRight, self.rearRight)
+        self.m_robotDrive = MecanumDrive(self.frontLeft, self.rearLeft, self.frontRight, self.rearRight)
 
         self.m_stick = Joystick(self.kJoystickChannel)
 
     def teleopPeriodic(self):
         # Use the joystick X axis for lateral movement, Y axis for forward
         # movement, and Z axis for rotation.
-        self.m_drive.driveCartesian(-self.m_stick.getY(), self.m_stick.getX(), self.m_stick.getZ(), 0)
+        self.m_robotDrive.driveCartesian(-self.m_stick.getY(), self.m_stick.getX(), self.m_stick.getZ(), 0)
 
 
 if __name__ == "__main__":

--- a/mecanum-drive/robot.py
+++ b/mecanum-drive/robot.py
@@ -5,9 +5,7 @@
 """
 
 import wpilib
-from wpilib.drive import MecanumDrive
-from wpilib import Joystick, PWMSparkMax, TimedRobot
-
+import wpilib.drive
 
 class MyRobot(TimedRobot):
     # Channels on the roboRIO that the motor controllers are plugged in to
@@ -20,24 +18,24 @@ class MyRobot(TimedRobot):
     kJoystickChannel = 0
 
     def robotInit(self):
-        self.frontLeft = PWMSparkMax(self.kFrontLeftChannel)
-        self.rearLeft = PWMSparkMax(self.kRearLeftChannel)
-        self.frontRight = PWMSparkMax(self.kFrontRightChannel)
-        self.rearRight = PWMSparkMax(self.kRearRightChannel)
+        self.frontLeft = wpilib.PWMSparkMax(self.kFrontLeftChannel)
+        self.rearLeft = wpilib.PWMSparkMax(self.kRearLeftChannel)
+        self.frontRight = wpilib.PWMSparkMax(self.kFrontRightChannel)
+        self.rearRight = wpilib.PWMSparkMax(self.kRearRightChannel)
 
         # invert the right side motors
         # you may need to change or remove this to match your robot
         self.frontRight.setInverted(True)
         self.rearRight.setInverted(True)
 
-        self.m_robotDrive = MecanumDrive(self.frontLeft, self.rearLeft, self.frontRight, self.rearRight)
+        self.robotDrive = wpilib.drive.MecanumDrive(self.frontLeft, self.rearLeft, self.frontRight, self.rearRight)
 
-        self.m_stick = Joystick(self.kJoystickChannel)
+        self.stick = wpilib.Joystick(self.kJoystickChannel)
 
     def teleopPeriodic(self):
         # Use the joystick X axis for lateral movement, Y axis for forward
         # movement, and Z axis for rotation.
-        self.m_robotDrive.driveCartesian(-self.m_stick.getY(), self.m_stick.getX(), self.m_stick.getZ(), 0)
+        self.robotDrive.driveCartesian(-self.stick.getY(), self.stick.getX(), self.stick.getZ(), 0)
 
 
 if __name__ == "__main__":

--- a/mecanum-drive/robot.py
+++ b/mecanum-drive/robot.py
@@ -7,6 +7,7 @@
 import wpilib
 import wpilib.drive
 
+
 class MyRobot(TimedRobot):
     # Channels on the roboRIO that the motor controllers are plugged in to
     kFrontLeftChannel = 2
@@ -28,14 +29,18 @@ class MyRobot(TimedRobot):
         self.frontRight.setInverted(True)
         self.rearRight.setInverted(True)
 
-        self.robotDrive = wpilib.drive.MecanumDrive(self.frontLeft, self.rearLeft, self.frontRight, self.rearRight)
+        self.robotDrive = wpilib.drive.MecanumDrive(
+            self.frontLeft, self.rearLeft, self.frontRight, self.rearRight
+        )
 
         self.stick = wpilib.Joystick(self.kJoystickChannel)
 
     def teleopPeriodic(self):
         # Use the joystick X axis for lateral movement, Y axis for forward
         # movement, and Z axis for rotation.
-        self.robotDrive.driveCartesian(-self.stick.getY(), self.stick.getX(), self.stick.getZ(), 0)
+        self.robotDrive.driveCartesian(
+            -self.stick.getY(), self.stick.getX(), self.stick.getZ(), 0
+        )
 
 
 if __name__ == "__main__":

--- a/mecanum-drive/robot.py
+++ b/mecanum-drive/robot.py
@@ -6,52 +6,38 @@
 
 import wpilib
 from wpilib.drive import MecanumDrive
+from wpilib import Joystick, PWMSparkMax, TimedRobot
 
 
-class MyRobot(wpilib.TimedRobot):
+class MyRobot(TimedRobot):
     # Channels on the roboRIO that the motor controllers are plugged in to
-    frontLeftChannel = 2
-    rearLeftChannel = 3
-    frontRightChannel = 1
-    rearRightChannel = 0
+    kFrontLeftChannel = 2
+    kRearLeftChannel = 3
+    kFrontRightChannel = 1
+    kRearRightChannel = 0
 
     # The channel on the driver station that the joystick is connected to
-    joystickChannel = 0
+    kJoystickChannel = 0
 
     def robotInit(self):
-        """Robot initialization function"""
-        self.frontLeftMotor = wpilib.Talon(self.frontLeftChannel)
-        self.rearLeftMotor = wpilib.Talon(self.rearLeftChannel)
-        self.frontRightMotor = wpilib.Talon(self.frontRightChannel)
-        self.rearRightMotor = wpilib.Talon(self.rearRightChannel)
+        self.frontLeft = PWMSparkMax(self.kFrontLeftChannel)
+        self.rearLeft = PWMSparkMax(self.kRearLeftChannel)
+        self.frontRight = PWMSparkMax(self.kFrontRightChannel)
+        self.rearRight = PWMSparkMax(self.kRearRightChannel)
 
-        # invert the left side motors
-        self.frontLeftMotor.setInverted(True)
-
+        # invert the right side motors
         # you may need to change or remove this to match your robot
-        self.rearLeftMotor.setInverted(True)
+        self.frontRight.setInverted(True)
+        self.rearRight.setInverted(True)
 
-        self.drive = MecanumDrive(
-            self.frontLeftMotor,
-            self.rearLeftMotor,
-            self.frontRightMotor,
-            self.rearRightMotor,
-        )
+        self.m_drive = MecanumDrive(self.frontLeft, self.rearLeft, self.frontRight, self.rearRight)
 
-        self.drive.setExpiration(0.1)
-
-        self.stick = wpilib.Joystick(self.joystickChannel)
-
-    def teleopInit(self):
-        self.drive.setSafetyEnabled(True)
+        self.m_stick = Joystick(self.kJoystickChannel)
 
     def teleopPeriodic(self):
-        """Runs the motors with Mecanum drive."""
-        # Use the joystick X axis for lateral movement, Y axis for forward movement, and Z axis for rotation.
-        # This sample does not use field-oriented drive, so the gyro input is set to zero.
-        self.drive.driveCartesian(
-            self.stick.getX(), self.stick.getY(), self.stick.getZ(), 0
-        )
+        # Use the joystick X axis for lateral movement, Y axis for forward
+        # movement, and Z axis for rotation.
+        self.m_drive.driveCartesian(-self.m_stick.getY(), self.m_stick.getX(), self.m_stick.getZ(), 0)
 
 
 if __name__ == "__main__":

--- a/mecanum-drive/robot.py
+++ b/mecanum-drive/robot.py
@@ -8,7 +8,7 @@ import wpilib
 import wpilib.drive
 
 
-class MyRobot(TimedRobot):
+class MyRobot(wpilib.TimedRobot):
     # Channels on the roboRIO that the motor controllers are plugged in to
     kFrontLeftChannel = 2
     kRearLeftChannel = 3


### PR DESCRIPTION
As stated in the #49 issue in the base repository, we need example code that matches WPIlib examples closely.

I may have broken some PEP guidelines, but I believe we need formatting to be in line with C++/Java examples.

The code has been tested in simulation only, because my team does not have any SparkMax motor controllers.