### PR TITLE
add arcade-drive-xbox-controller example

### DIFF
--- a/arcade-drive-xbox-controller/robot.py
+++ b/arcade-drive-xbox-controller/robot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
     This is a demo program showing the use of the DifferentialDrive class.
-    Runs the motors with arcade steering.
+    Runs the motors with split arcade steering and an Xbox controller.
 """
 
 import wpilib
@@ -19,8 +19,8 @@ class MyRobot(wpilib.TimedRobot):
         # object that handles basic drive operations
         self.robotDrive = wpilib.drive.DifferentialDrive(left, right)
 
-        # joystick 0 on the driver station
-        self.stick = wpilib.Joystick(0)
+        # xbox controller 0 on the driver station
+        self.driverController = wpilib.XboxController(0)
 
         # We need to invert one side of the drivetrain so that positive voltages
         # result in both sides moving forward. Depending on how your robot's
@@ -31,7 +31,9 @@ class MyRobot(wpilib.TimedRobot):
         # Drive with split arcade style
         # That means that the Y axis of the left stick moves forward
         # and backward, and the X of the right stick turns left and right.
-        self.robotDrive.arcadeDrive(-self.stick.getY(), -self.stick.getX())
+        self.robotDrive.arcadeDrive(
+            -self.driverController.getLeftY(), -self.driverController.getRightX()
+        )
 
 
 if __name__ == "__main__":

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,6 +6,7 @@ cd "$(dirname $0)"
 BASE_TESTS="
   addressableled
   arcade-drive
+  arcade-drive-xbox-controller
   arm-simulation
   canpdp
   commands-v2/hatchbot


### PR DESCRIPTION
I added comments to match [the cpp example](https://github.com/wpilibsuite/allwpilib/blob/main/wpilibcExamples/src/main/cpp/examples/ArcadeDriveXboxController/cpp/Robot.cpp).  Let me know if you'd rather it be a little simpler like the existing arcade-drive example.

Confirmed it runs in sim