### PR TITLE
Add mecanum-bot example

### DIFF
--- a/mecanum-bot/drivetrain.py
+++ b/mecanum-bot/drivetrain.py
@@ -116,15 +116,14 @@ class Drivetrain:
     ):
         """Method to drive the robot using joystick info."""
         mecanumDriveWheelSpeeds = self.kinematics.toWheelSpeeds(
-            ChassisSpeeds.fromFieldRelativeSpeeds(
-                xSpeed, ySpeed, rot, self.gyro.getRotation2d()
+            ChassisSpeeds.discretize(
+                ChassisSpeeds.fromFieldRelativeSpeeds(
+                    xSpeed, ySpeed, rot, self.gyro.getRotation2d()
+                )
+                if fieldRelative
+                else ChassisSpeeds(xSpeed, ySpeed, rot),
+                periodSeconds,
             )
-            if fieldRelative
-            else ChassisSpeeds(xSpeed, ySpeed, rot)
-            # ChassisSpeeds.discretize(
-            #    ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rot, self.gyro.getRotation2d()) if fieldRelative else ChassisSpeeds(xSpeed, ySpeed, rot),
-            #    periodSeconds
-            # )
         )
         mecanumDriveWheelSpeeds.desaturate(self.MAX_SPEED)
         self.setSpeeds(mecanumDriveWheelSpeeds)

--- a/mecanum-bot/drivetrain.py
+++ b/mecanum-bot/drivetrain.py
@@ -1,4 +1,8 @@
-#!/usr/bin/env python3
+#
+# Copyright (c) FIRST and other WPILib contributors.
+# Open Source Software; you can modify and/or share it under the terms of
+# the WPILib BSD license file in the root directory of this project.
+#
 
 import wpilib.drive
 import wpimath.controller
@@ -12,12 +16,8 @@ import math
 class Drivetrain:
     """Represents a differential drive style drivetrain."""
 
-    MAX_SPEED = 3.0  # 3 meters per second
-    MAX_ANGULAR_SPEED = math.pi  # 1/2 rotation per second
-
-    # TRACK_WIDTH = 0.381 * 2  # meters
-    # WHEEL_RADIUS = 0.0508  # meters
-    # ENCODER_RESOLUTION = 4096  # counts per revolution
+    kMaxSpeed = 3.0  # 3 meters per second
+    kMaxAngularSpeed = math.pi  # 1/2 rotation per second
 
     def __init__(self):
         self.frontLeftMotor = wpilib.PWMSparkMax(1)
@@ -125,7 +125,7 @@ class Drivetrain:
                 periodSeconds,
             )
         )
-        mecanumDriveWheelSpeeds.desaturate(self.MAX_SPEED)
+        mecanumDriveWheelSpeeds.desaturate(self.kMaxSpeed)
         self.setSpeeds(mecanumDriveWheelSpeeds)
 
     def updateOdometry(self):

--- a/mecanum-bot/drivetrain.py
+++ b/mecanum-bot/drivetrain.py
@@ -46,7 +46,9 @@ class Drivetrain:
             frontLeftLocation, frontRightLocation, backLeftLocation, backRightLocation
         )
 
-        self.odometry = wpimath.kinematics.MecanumDriveOdometry(self.kinematics, self.gyro.getRotation2d(), self.getCurrentDistances())
+        self.odometry = wpimath.kinematics.MecanumDriveOdometry(
+            self.kinematics, self.gyro.getRotation2d(), self.getCurrentDistances()
+        )
 
         # Gains are for example purposes only - must be determined for your own robot!
         self.feedforward = wpimath.controller.SimpleMotorFeedforwardMeters(1, 3)
@@ -104,14 +106,21 @@ class Drivetrain:
         self.backLeftMotor.setVoltage(backLeftOutput + backLeftFeedforward)
         self.backRightMotor.setVoltage(backRightOutput + backRightFeedforward)
 
-    def drive(self, xSpeed: float, ySpeed: float, rot: float, fieldRelative: bool, periodSeconds: float):
+    def drive(
+        self,
+        xSpeed: float,
+        ySpeed: float,
+        rot: float,
+        fieldRelative: bool,
+        periodSeconds: float,
+    ):
         """Method to drive the robot using joystick info."""
         mecanumDriveWheelSpeeds = self.kinematics.toWheelSpeeds(
             ChassisSpeeds.fromFieldRelativeSpeeds(
                 xSpeed, ySpeed, rot, self.gyro.getRotation2d()
-            ) if fieldRelative else (
-                ChassisSpeeds(xSpeed, ySpeed, rot)
             )
+            if fieldRelative
+            else ChassisSpeeds(xSpeed, ySpeed, rot)
             # ChassisSpeeds.discretize(
             #    ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rot, self.gyro.getRotation2d()) if fieldRelative else ChassisSpeeds(xSpeed, ySpeed, rot),
             #    periodSeconds

--- a/mecanum-bot/drivetrain.py
+++ b/mecanum-bot/drivetrain.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import wpilib.drive
+import wpimath.controller
+import wpimath.geometry
+from wpimath.kinematics import ChassisSpeeds
+import wpimath.units
+
+import math
+
+
+class Drivetrain:
+    """Represents a differential drive style drivetrain."""
+
+    MAX_SPEED = 3.0  # 3 meters per second
+    MAX_ANGULAR_SPEED = math.pi  # 1/2 rotation per second
+
+    # TRACK_WIDTH = 0.381 * 2  # meters
+    # WHEEL_RADIUS = 0.0508  # meters
+    # ENCODER_RESOLUTION = 4096  # counts per revolution
+
+    def __init__(self):
+        self.frontLeftMotor = wpilib.PWMSparkMax(1)
+        self.frontRightMotor = wpilib.PWMSparkMax(2)
+        self.backLeftMotor = wpilib.PWMSparkMax(3)
+        self.backRightMotor = wpilib.PWMSparkMax(4)
+
+        self.frontLeftEncoder = wpilib.Encoder(0, 1)
+        self.frontRightEncoder = wpilib.Encoder(2, 3)
+        self.backLeftEncoder = wpilib.Encoder(4, 5)
+        self.backRightEncoder = wpilib.Encoder(6, 7)
+
+        frontLeftLocation = wpimath.geometry.Translation2d(0.381, 0.381)
+        frontRightLocation = wpimath.geometry.Translation2d(0.381, -0.381)
+        backLeftLocation = wpimath.geometry.Translation2d(-0.381, 0.381)
+        backRightLocation = wpimath.geometry.Translation2d(-0.381, -0.381)
+
+        self.frontLeftPIDController = wpimath.controller.PIDController(1, 0, 0)
+        self.frontRightPIDController = wpimath.controller.PIDController(1, 0, 0)
+        self.backLeftPIDController = wpimath.controller.PIDController(1, 0, 0)
+        self.backRightPIDController = wpimath.controller.PIDController(1, 0, 0)
+
+        self.gyro = wpilib.AnalogGyro(0)
+
+        self.kinematics = wpimath.kinematics.MecanumDriveKinematics(
+            frontLeftLocation, frontRightLocation, backLeftLocation, backRightLocation
+        )
+
+        self.odometry = wpimath.kinematics.MecanumDriveOdometry(self.kinematics, self.gyro.getRotation2d(), self.getCurrentDistances())
+
+        # Gains are for example purposes only - must be determined for your own robot!
+        self.feedforward = wpimath.controller.SimpleMotorFeedforwardMeters(1, 3)
+
+        self.gyro.reset()
+
+        # We need to invert one side of the drivetrain so that positive voltages
+        # result in both sides moving forward. Depending on how your robot's
+        # gearbox is constructed, you might have to invert the left side instead.
+        self.frontRightMotor.setInverted(True)
+        self.backRightMotor.setInverted(True)
+
+    def getCurrentState(self) -> wpimath.kinematics.MecanumDriveWheelSpeeds:
+        """Returns the current state of the drivetrain."""
+        return wpimath.kinematics.MecanumDriveWheelSpeeds(
+            self.frontLeftEncoder.getRate(),
+            self.frontRightEncoder.getRate(),
+            self.backLeftEncoder.getRate(),
+            self.backRightEncoder.getRate(),
+        )
+
+    def getCurrentDistances(self) -> wpimath.kinematics.MecanumDriveWheelPositions:
+        """Returns the current distances measured by the drivetrain."""
+        pos = wpimath.kinematics.MecanumDriveWheelPositions()
+
+        pos.frontLeft = self.frontLeftEncoder.getDistance()
+        pos.frontRight = self.frontRightEncoder.getDistance()
+        pos.rearLeft = self.backLeftEncoder.getDistance()
+        pos.rearRight = self.backRightEncoder.getDistance()
+
+        return pos
+
+    def setSpeeds(self, speeds: wpimath.kinematics.MecanumDriveWheelSpeeds):
+        """Sets the desired speeds for each wheel."""
+        frontLeftFeedforward = self.feedforward.calculate(speeds.frontLeft)
+        frontRightFeedforward = self.feedforward.calculate(speeds.frontRight)
+        backLeftFeedforward = self.feedforward.calculate(speeds.rearLeft)
+        backRightFeedforward = self.feedforward.calculate(speeds.rearRight)
+
+        frontLeftOutput = self.frontLeftPIDController.calculate(
+            self.frontLeftEncoder.getRate(), speeds.frontLeft
+        )
+        frontRightOutput = self.frontRightPIDController.calculate(
+            self.frontRightEncoder.getRate(), speeds.frontRight
+        )
+        backLeftOutput = self.frontLeftPIDController.calculate(
+            self.backLeftEncoder.getRate(), speeds.rearLeft
+        )
+        backRightOutput = self.frontRightPIDController.calculate(
+            self.backRightEncoder.getRate(), speeds.rearRight
+        )
+
+        self.frontLeftMotor.setVoltage(frontLeftOutput + frontLeftFeedforward)
+        self.frontRightMotor.setVoltage(frontRightOutput + frontRightFeedforward)
+        self.backLeftMotor.setVoltage(backLeftOutput + backLeftFeedforward)
+        self.backRightMotor.setVoltage(backRightOutput + backRightFeedforward)
+
+    def drive(self, xSpeed: float, ySpeed: float, rot: float, fieldRelative: bool, periodSeconds: float):
+        """Method to drive the robot using joystick info."""
+        mecanumDriveWheelSpeeds = self.kinematics.toWheelSpeeds(
+            ChassisSpeeds.fromFieldRelativeSpeeds(
+                xSpeed, ySpeed, rot, self.gyro.getRotation2d()
+            ) if fieldRelative else (
+                ChassisSpeeds(xSpeed, ySpeed, rot)
+            )
+            # ChassisSpeeds.discretize(
+            #    ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rot, self.gyro.getRotation2d()) if fieldRelative else ChassisSpeeds(xSpeed, ySpeed, rot),
+            #    periodSeconds
+            # )
+        )
+        mecanumDriveWheelSpeeds.desaturate(self.MAX_SPEED)
+        self.setSpeeds(mecanumDriveWheelSpeeds)
+
+    def updateOdometry(self):
+        """Updates the field-relative position."""
+        self.odometry.update(self.gyro.getRotation2d(), self.getCurrentDistances())

--- a/mecanum-bot/robot.py
+++ b/mecanum-bot/robot.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import wpilib
+import wpilib.drive
+import wpimath.filter
+
+from drivetrain import Drivetrain
+
+
+class MyRobot(wpilib.TimedRobot):
+    def robotInit(self):
+        self.controller = wpilib.XboxController(0)
+        self.mecanum = Drivetrain()
+
+        # Slew rate limiters to make joystick inputs more gentle; 1/3 sec from 0 to 1.
+        self.xspeedLimiter = wpimath.filter.SlewRateLimiter(3)
+        self.yspeedLimiter = wpimath.filter.SlewRateLimiter(3)
+        self.rotLimiter = wpimath.filter.SlewRateLimiter(3)
+
+    def autonomousPeriodic(self):
+        self._driveWithJoystick(False)
+        self.mecanum.updateOdometry()
+
+    def teleopPeriodic(self):
+        self._driveWithJoystick(True)
+
+    def _driveWithJoystick(self, fieldRelative: bool):
+        # Get the x speed. We are inverting this because Xbox controllers return
+        # negative values when we push forward.
+        xSpeed = (
+            -self.xspeedLimiter.calculate(self.controller.getLeftY())
+            * Drivetrain.MAX_SPEED
+        )
+
+        # Get the y speed or sideways/strafe speed. We are inverting this because
+        # we want a positive value when we pull to the left. Xbox controllers
+        # return positive values when you pull to the right by default.
+        ySpeed = (
+            -self.yspeedLimiter.calculate(self.controller.getLeftX())
+            * Drivetrain.MAX_SPEED
+        )
+
+        # Get the rate of angular rotation. We are inverting this because we want a
+        # positive value when we pull to the left (remember, CCW is positive in
+        # mathematics). Xbox controllers return positive values when you pull to
+        # the right by default.
+        rot = (
+            -self.rotLimiter.calculate(self.controller.getRightX())
+            * Drivetrain.MAX_ANGULAR_SPEED
+        )
+
+        self.mecanum.drive(xSpeed, ySpeed, rot, fieldRelative, self.getPeriod())
+
+
+if __name__ == "__main__":
+    wpilib.run(MyRobot)

--- a/mecanum-bot/robot.py
+++ b/mecanum-bot/robot.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) FIRST and other WPILib contributors.
+# Open Source Software; you can modify and/or share it under the terms of
+# the WPILib BSD license file in the root directory of this project.
+#
 
 import wpilib
 import wpilib.drive
@@ -29,7 +34,7 @@ class MyRobot(wpilib.TimedRobot):
         # negative values when we push forward.
         xSpeed = (
             -self.xspeedLimiter.calculate(self.controller.getLeftY())
-            * Drivetrain.MAX_SPEED
+            * Drivetrain.kMaxSpeed
         )
 
         # Get the y speed or sideways/strafe speed. We are inverting this because
@@ -37,7 +42,7 @@ class MyRobot(wpilib.TimedRobot):
         # return positive values when you pull to the right by default.
         ySpeed = (
             -self.yspeedLimiter.calculate(self.controller.getLeftX())
-            * Drivetrain.MAX_SPEED
+            * Drivetrain.kMaxSpeed
         )
 
         # Get the rate of angular rotation. We are inverting this because we want a
@@ -46,7 +51,7 @@ class MyRobot(wpilib.TimedRobot):
         # the right by default.
         rot = (
             -self.rotLimiter.calculate(self.controller.getRightX())
-            * Drivetrain.MAX_ANGULAR_SPEED
+            * Drivetrain.kMaxAngularSpeed
         )
 
         self.mecanum.drive(xSpeed, ySpeed, rot, fieldRelative, self.getPeriod())

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -22,6 +22,7 @@ BASE_TESTS="
   gyro
   i2c-communication
   magicbot-simple
+  mecanum-bot
   mecanum-drive
   mecanum-driveXbox
   mechanism2d


### PR DESCRIPTION
wpimath.kinematics.ChassisSpeeds.descretize(...) doesn't seem to exist.  Am I missing it somewhere? Is it new and needs to be added? Is there a different/better approach?

RobotPy docs: https://robotpy.readthedocs.io/projects/wpimath/en/latest/wpimath.kinematics/ChassisSpeeds.html
wpilibj source: https://github.com/wpilibsuite/allwpilib/blob/main/wpimath/src/main/java/edu/wpi/first/math/kinematics/ChassisSpeeds.java#L92
