### PR TITLE
Changed the swervemodule getPosition function to use encoder distance

### DIFF
--- a/SwerveBot/swervemodule.py
+++ b/SwerveBot/swervemodule.py
@@ -94,7 +94,7 @@ class SwerveModule:
         :returns: The current position of the module.
         """
         return wpimath.kinematics.SwerveModulePosition(
-            self.driveEncoder.getRate(),
+            self.driveEncoder.getDistance(),
             wpimath.geometry.Rotation2d(self.turningEncoder.getDistance()),
         )
 


### PR DESCRIPTION
The previous implementation of the SwerveModule class getPosition method took the rate of the drive encoder (corresponding to velocity) instead of its distance. I changed it to use the distance instead.
The java implementation using distance is [here](https://github.com/wpilibsuite/allwpilib/blob/main/wpilibjExamples/src/main/java/edu/wpi/first/wpilibj/examples/swervebot/SwerveModule.java)