### PR TITLE
Add pre-commit config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: psf/black@stable
-
-  check-file-headers:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
-      with:
-        python-version: 3.12
-    - name: Check header
-      run: python ./check_header.py
-      shell: bash
+    - uses: pre-commit/action@v3.0.1
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+---
+repos:
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.10.0
+    hooks:
+      - id: black
+  - repo: local
+    hooks:
+      - id: check-headers
+        name: check headers
+        language: script
+        entry: check_header.py
+        pass_filenames: false
+        require_serial: true
+        types: [python]


### PR DESCRIPTION
This intends to do two things:

1. Pin the black version, so we don't get surprised by the annual black major release suddenly failing CI.
2. Make it easier for first-time contributors to discover the formatters/linters we have, and make these checks easier to reproduce locally (e.g. `pre-commit run --all-files`).