### PR TITLE
Update examples using MotorControllerGroup

### DIFF
--- a/ArmBot/subsystems/drivesubsystem.py
+++ b/ArmBot/subsystems/drivesubsystem.py
@@ -4,8 +4,8 @@
 # the WPILib BSD license file in the root directory of this project.
 #
 
-import wpilib
-import wpilib.drive
+from wpilib import PWMSparkMax, Encoder
+from wpilib.drive import DifferentialDrive
 import commands2
 
 import constants
@@ -15,31 +15,30 @@ class DriveSubsystem(commands2.Subsystem):
     # Creates a new DriveSubsystem
     def __init__(self) -> None:
         super().__init__()
+   
+        # The motors on the left side of the drive.
+        self.left1 = PWMSparkMax(constants.DriveConstants.kLeftMotor1Port)
+        self.left2 = PWMSparkMax(constants.DriveConstants.kLeftMotor2Port)
 
-        # The motors on the left side of the drive
-        self.left_motors = wpilib.MotorControllerGroup(
-            wpilib.PWMSparkMax(constants.DriveConstants.kLeftMotor1Port),
-            wpilib.PWMSparkMax(constants.DriveConstants.kLeftMotor2Port),
-        )
+        # The motors on the right side of the drive.
+        self.right1 = PWMSparkMax(constants.DriveConstants.kRightMotor1Port)
+        self.right2 = PWMSparkMax(constants.DriveConstants.kRightMotor2Port)
 
-        # The motors on the right side of the drive
-        self.right_motors = wpilib.MotorControllerGroup(
-            wpilib.PWMSparkMax(constants.DriveConstants.kRightMotor1Port),
-            wpilib.PWMSparkMax(constants.DriveConstants.kRightMotor2Port),
-        )
+        self.left1.addFollower(self.left2)
+        self.right1.addFollower(self.right2)
 
         # The robot's drive
-        self.drive = wpilib.drive.DifferentialDrive(self.left_motors, self.right_motors)
+        self.drive = DifferentialDrive(self.left1, self.right1)
 
         # The left-side drive encoder
-        self.left_encoder = wpilib.Encoder(
+        self.left_encoder = Encoder(
             constants.DriveConstants.kLeftEncoderPorts[0],
             constants.DriveConstants.kLeftEncoderPorts[1],
             constants.DriveConstants.kLeftEncoderReversed,
         )
 
         # The right-side drive encoder
-        self.right_encoder = wpilib.Encoder(
+        self.right_encoder = Encoder(
             constants.DriveConstants.kRightEncoderPorts[0],
             constants.DriveConstants.kRightEncoderPorts[1],
             constants.DriveConstants.kRightEncoderReversed,
@@ -56,7 +55,7 @@ class DriveSubsystem(commands2.Subsystem):
         # We need to invert one side of the drivetrain so that positive voltages
         # result in both sides moving forward. Depending on how your robot's
         # gearbox is constructed, you might have to invert the left side instead.
-        self.right_motors.setInverted(True)
+        self.right1.setInverted(True)
 
     def arcadeDrive(self, fwd: float, rot: float) -> None:
         """Drives the robot using arcade controls.
@@ -80,14 +79,14 @@ class DriveSubsystem(commands2.Subsystem):
             self.left_encoder.getDistance() + self.right_encoder.getDistance()
         ) / 2.0
 
-    def getLeftEncoder(self) -> wpilib.Encoder:
+    def getLeftEncoder(self) -> Encoder:
         """Gets the left drive encoder.
 
         :returns: the left drive encoder
         """
         return self.left_encoder
 
-    def getRightEncoder(self) -> wpilib.Encoder:
+    def getRightEncoder(self) -> Encoder:
         """Gets the right drive encoder.
 
         :returns: the right drive encoder

--- a/ArmBot/subsystems/drivesubsystem.py
+++ b/ArmBot/subsystems/drivesubsystem.py
@@ -15,7 +15,7 @@ class DriveSubsystem(commands2.Subsystem):
     # Creates a new DriveSubsystem
     def __init__(self) -> None:
         super().__init__()
-   
+
         # The motors on the left side of the drive.
         self.left1 = PWMSparkMax(constants.DriveConstants.kLeftMotor1Port)
         self.left2 = PWMSparkMax(constants.DriveConstants.kLeftMotor2Port)

--- a/ArmBotOffboard/subsystems/drivesubsystem.py
+++ b/ArmBotOffboard/subsystems/drivesubsystem.py
@@ -18,7 +18,7 @@ class DriveSubsystem(commands2.Subsystem):
     def __init__(self) -> None:
         super().__init__()
 
-       # The motors on the left side of the drive.
+        # The motors on the left side of the drive.
         self.left1 = PWMSparkMax(constants.kLeftMotor1Port)
         self.left2 = PWMSparkMax(constants.kLeftMotor2Port)
 

--- a/ArmBotOffboard/subsystems/drivesubsystem.py
+++ b/ArmBotOffboard/subsystems/drivesubsystem.py
@@ -4,42 +4,43 @@
 # the WPILib BSD license file in the root directory of this project.
 #
 
+import typing
+
 import commands2
 import commands2.cmd
+from wpilib import PWMSparkMax, Encoder
+from wpilib.drive import DifferentialDrive
+
 import constants
-import wpilib
-import wpilib.drive
-import typing
 
 
 class DriveSubsystem(commands2.Subsystem):
     def __init__(self) -> None:
         super().__init__()
 
-        # The motors on the left side of the drive.
-        self.left = wpilib.MotorControllerGroup(
-            wpilib.PWMSparkMax(constants.kLeftMotor1Port),
-            wpilib.PWMSparkMax(constants.kLeftMotor2Port),
-        )
+       # The motors on the left side of the drive.
+        self.left1 = PWMSparkMax(constants.kLeftMotor1Port)
+        self.left2 = PWMSparkMax(constants.kLeftMotor2Port)
 
         # The motors on the right side of the drive.
-        self.right = wpilib.MotorControllerGroup(
-            wpilib.PWMSparkMax(constants.kRightMotor1Port),
-            wpilib.PWMSparkMax(constants.kRightMotor2Port),
-        )
+        self.right1 = PWMSparkMax(constants.kRightMotor1Port)
+        self.right2 = PWMSparkMax(constants.kRightMotor2Port)
+
+        self.left1.addFollower(self.left2)
+        self.right1.addFollower(self.right2)
 
         # The robot's drive
-        self.drive = wpilib.drive.DifferentialDrive(self.left, self.right)
+        self.drive = DifferentialDrive(self.left1, self.right1)
 
         # The left-side drive encoder
-        self.left_encoder = wpilib.Encoder(
+        self.left_encoder = Encoder(
             constants.kLeftEncoderPorts[0],
             constants.kLeftEncoderPorts[1],
             constants.kLeftEncoderReversed,
         )
 
         # The right-side drive encoder
-        self.right_encoder = wpilib.Encoder(
+        self.right_encoder = Encoder(
             constants.kRightEncoderPorts[0],
             constants.kRightEncoderPorts[1],
             constants.kRightEncoderReversed,
@@ -52,7 +53,7 @@ class DriveSubsystem(commands2.Subsystem):
         # We need to invert one side of the drivetrain so that positive voltages
         # result in both sides moving forward. Depending on how your robot's
         # gearbox is constructed, you might have to invert the left side instead.
-        self.right.setInverted(True)
+        self.right1.setInverted(True)
 
     def arcadeDriveCommand(
         self, fwd: typing.Callable[[], float], rot: typing.Callable[[], float]
@@ -71,8 +72,8 @@ class DriveSubsystem(commands2.Subsystem):
 
     def resetEncoders(self) -> None:
         """Resets the drive encoders to currently read a position of 0."""
-        self.left.reset()
-        self.right.reset()
+        self.left_encoder.reset()
+        self.right_encoder.reset()
 
     def getAverageEncoderDistance(self) -> float:
         """Gets the average distance of the two encoders.
@@ -82,7 +83,7 @@ class DriveSubsystem(commands2.Subsystem):
         """
         return (self.left_encoder.getDistance() + self.right_encoder.getDistance()) / 2
 
-    def getLeftEncoder(self) -> wpilib.Encoder:
+    def getLeftEncoder(self) -> Encoder:
         """Gets the left drive encoder.
 
         Returns:
@@ -90,7 +91,7 @@ class DriveSubsystem(commands2.Subsystem):
         """
         return self.left_encoder
 
-    def getRightEncoder(self) -> wpilib.Encoder:
+    def getRightEncoder(self) -> Encoder:
         """Gets the right drive encoder.
 
         Returns:

--- a/DifferentialDriveBot/drivetrain.py
+++ b/DifferentialDriveBot/drivetrain.py
@@ -38,9 +38,6 @@ class Drivetrain:
         # gearbox is constructed, you might have to invert the left side instead.
         self.rightLeader.setInverted(True)
 
-        # turns the motors into a group so that we can set voltage to both at once
-        self.robotDrive = wpilib.drive.DifferentialDrive(self.leftLeader, self.rightLeader)
-
 
         self.leftEncoder = wpilib.Encoder(0, 1)
         self.rightEncoder = wpilib.Encoder(2, 3)
@@ -96,8 +93,9 @@ class Drivetrain:
         )
 
         # Controls the left and right sides of the robot using the calculated outputs
-        self.robotDrive.tankDrive(leftOutput + leftFeedforward, rightOutput + rightFeedforward)
-        
+        self.leftLeader.setVoltage(leftOutput + leftFeedforward)
+        self.rightLeader.setVoltage(rightOutput + rightFeedforward)
+
 
     def drive(self, xSpeed, rot):
         """Drives the robot with the given linear velocity and angular velocity."""

--- a/DifferentialDriveBot/drivetrain.py
+++ b/DifferentialDriveBot/drivetrain.py
@@ -54,10 +54,6 @@ class Drivetrain:
 
         self.gyro.reset()
 
-        # We need to invert one side of the drivetrain so that positive voltages
-        # result in both sides moving forward. Depending on how your robot's
-        # gearbox is constructed, you might have to invert the left side instead.
-
         # Set the distance per pulse for the drive encoders. We can simply use the
         # distance traveled for one rotation of the wheel divided by the encoder
         # resolution.
@@ -92,7 +88,6 @@ class Drivetrain:
         # Controls the left and right sides of the robot using the calculated outputs
         self.leftLeader.setVoltage(leftOutput + leftFeedforward)
         self.rightLeader.setVoltage(rightOutput + rightFeedforward)
-
 
     def drive(self, xSpeed, rot):
         """Drives the robot with the given linear velocity and angular velocity."""

--- a/DifferentialDriveBot/drivetrain.py
+++ b/DifferentialDriveBot/drivetrain.py
@@ -28,7 +28,6 @@ class Drivetrain:
         self.rightLeader = wpilib.PWMSparkMax(3)
         self.rightFollower = wpilib.PWMSparkMax(4)
 
-        
         # Make sure both motors for each side are in the same group
         self.leftLeader.addFollower(self.leftFollower)
         self.rightLeader.addFollower(self.rightFollower)
@@ -38,10 +37,8 @@ class Drivetrain:
         # gearbox is constructed, you might have to invert the left side instead.
         self.rightLeader.setInverted(True)
 
-
         self.leftEncoder = wpilib.Encoder(0, 1)
         self.rightEncoder = wpilib.Encoder(2, 3)
-
 
         self.gyro = wpilib.AnalogGyro(0)
 

--- a/DifferentialDriveBot/drivetrain.py
+++ b/DifferentialDriveBot/drivetrain.py
@@ -23,16 +23,28 @@ class Drivetrain:
     ENCODER_RESOLUTION = 4096  # counts per revolution
 
     def __init__(self):
-        leftLeader = wpilib.PWMSparkMax(1)
-        leftFollower = wpilib.PWMSparkMax(2)
-        rightLeader = wpilib.PWMSparkMax(3)
-        rightFollower = wpilib.PWMSparkMax(4)
+        self.leftLeader = wpilib.PWMSparkMax(1)
+        self.leftFollower = wpilib.PWMSparkMax(2)
+        self.rightLeader = wpilib.PWMSparkMax(3)
+        self.rightFollower = wpilib.PWMSparkMax(4)
+
+        
+        # Make sure both motors for each side are in the same group
+        self.leftLeader.addFollower(self.leftFollower)
+        self.rightLeader.addFollower(self.rightFollower)
+
+        # We need to invert one side of the drivetrain so that positive voltages
+        # result in both sides moving forward. Depending on how your robot's
+        # gearbox is constructed, you might have to invert the left side instead.
+        self.rightLeader.setInverted(True)
+
+        # turns the motors into a group so that we can set voltage to both at once
+        self.robotDrive = wpilib.drive.DifferentialDrive(self.leftLeader, self.rightLeader)
+
 
         self.leftEncoder = wpilib.Encoder(0, 1)
         self.rightEncoder = wpilib.Encoder(2, 3)
 
-        self.leftGroup = wpilib.MotorControllerGroup(leftLeader, leftFollower)
-        self.rightGroup = wpilib.MotorControllerGroup(rightLeader, rightFollower)
 
         self.gyro = wpilib.AnalogGyro(0)
 
@@ -51,7 +63,6 @@ class Drivetrain:
         # We need to invert one side of the drivetrain so that positive voltages
         # result in both sides moving forward. Depending on how your robot's
         # gearbox is constructed, you might have to invert the left side instead.
-        self.rightGroup.setInverted(True)
 
         # Set the distance per pulse for the drive encoders. We can simply use the
         # distance traveled for one rotation of the wheel divided by the encoder
@@ -84,8 +95,9 @@ class Drivetrain:
             self.rightEncoder.getRate(), speeds.right
         )
 
-        self.leftGroup.setVoltage(leftOutput + leftFeedforward)
-        self.rightGroup.setVoltage(rightOutput + rightFeedforward)
+        # Controls the left and right sides of the robot using the calculated outputs
+        self.robotDrive.tankDrive(leftOutput + leftFeedforward, rightOutput + rightFeedforward)
+        
 
     def drive(self, xSpeed, rot):
         """Drives the robot with the given linear velocity and angular velocity."""

--- a/FrisbeeBot/subsystems/drivesubsystem.py
+++ b/FrisbeeBot/subsystems/drivesubsystem.py
@@ -16,7 +16,7 @@ class DriveSubsystem(commands2.Subsystem):
         """Creates a new DriveSubsystem"""
         super().__init__()
 
-       # The motors on the left side of the drive.
+        # The motors on the left side of the drive.
         self.left1 = PWMSparkMax(constants.DriveConstants.kLeftMotor1Port)
         self.left2 = PWMSparkMax(constants.DriveConstants.kLeftMotor2Port)
 

--- a/FrisbeeBot/subsystems/drivesubsystem.py
+++ b/FrisbeeBot/subsystems/drivesubsystem.py
@@ -4,8 +4,8 @@
 # the WPILib BSD license file in the root directory of this project.
 #
 
-import wpilib
-import wpilib.drive
+from wpilib import PWMSparkMax, Encoder
+from wpilib.drive import DifferentialDrive
 import commands2
 
 import constants
@@ -16,30 +16,29 @@ class DriveSubsystem(commands2.Subsystem):
         """Creates a new DriveSubsystem"""
         super().__init__()
 
-        # The motors on the left side of the drive.
-        self.leftMotors = wpilib.MotorControllerGroup(
-            wpilib.PWMSparkMax(constants.DriveConstants.kLeftMotor1Port),
-            wpilib.PWMSparkMax(constants.DriveConstants.kLeftMotor2Port),
-        )
+       # The motors on the left side of the drive.
+        self.left1 = PWMSparkMax(constants.DriveConstants.kLeftMotor1Port)
+        self.left2 = PWMSparkMax(constants.DriveConstants.kLeftMotor2Port)
 
         # The motors on the right side of the drive.
-        self.rightMotors = wpilib.MotorControllerGroup(
-            wpilib.PWMSparkMax(constants.DriveConstants.kRightMotor1Port),
-            wpilib.PWMSparkMax(constants.DriveConstants.kRightMotor2Port),
-        )
+        self.right1 = PWMSparkMax(constants.DriveConstants.kRightMotor1Port)
+        self.right2 = PWMSparkMax(constants.DriveConstants.kRightMotor2Port)
+
+        self.left1.addFollower(self.left2)
+        self.right1.addFollower(self.right2)
 
         # The robot's drive
-        self.drive = wpilib.drive.DifferentialDrive(self.leftMotors, self.rightMotors)
+        self.drive = DifferentialDrive(self.left1, self.right1)
 
         # The left-side drive encoder
-        self.leftEncoder = wpilib.Encoder(
+        self.leftEncoder = Encoder(
             constants.DriveConstants.kLeftEncoderPorts[0],
             constants.DriveConstants.kLeftEncoderPorts[1],
             constants.DriveConstants.kLeftEncoderReversed,
         )
 
         # The right-side drive encoder
-        self.rightEncoder = wpilib.Encoder(
+        self.rightEncoder = Encoder(
             constants.DriveConstants.kRightEncoderPorts[0],
             constants.DriveConstants.kRightEncoderPorts[1],
             constants.DriveConstants.kRightEncoderReversed,
@@ -48,7 +47,7 @@ class DriveSubsystem(commands2.Subsystem):
         # We need to invert one side of the drivetrain so that positive voltages
         # result in both sides moving forward. Depending on how your robot's
         # gearbox is constructed, you might have to invert the left side instead.
-        self.rightMotors.setInverted(True)
+        self.right1.setInverted(True)
 
         # Sets the distance per pulse for the encoders
         self.leftEncoder.setDistancePerPulse(
@@ -80,7 +79,7 @@ class DriveSubsystem(commands2.Subsystem):
         """
         return (self.leftEncoder.getDistance() + self.rightEncoder.getDistance()) / 2.0
 
-    def getLeftEncoder(self) -> wpilib.Encoder:
+    def getLeftEncoder(self) -> Encoder:
         """
         Gets the left drive encoder.
 
@@ -88,7 +87,7 @@ class DriveSubsystem(commands2.Subsystem):
         """
         return self.leftEncoder
 
-    def getRightEncoder(self) -> wpilib.Encoder:
+    def getRightEncoder(self) -> Encoder:
         """
         Gets the right drive encoder.
 

--- a/GyroDriveCommands/subsystems/drivesubsystem.py
+++ b/GyroDriveCommands/subsystems/drivesubsystem.py
@@ -4,8 +4,8 @@
 # the WPILib BSD license file in the root directory of this project.
 #
 
-import wpilib
-import wpilib.drive
+from wpilib import PWMSparkMax, Encoder, ADXRS450_Gyro
+from wpilib.drive import DifferentialDrive
 import commands2
 import math
 
@@ -17,30 +17,30 @@ class DriveSubsystem(commands2.Subsystem):
         """Creates a new DriveSubsystem"""
         super().__init__()
 
-        # The motors on the left side of the drive.
-        self.leftMotors = wpilib.MotorControllerGroup(
-            wpilib.PWMSparkMax(constants.DriveConstants.kLeftMotor1Port),
-            wpilib.PWMSparkMax(constants.DriveConstants.kLeftMotor2Port),
-        )
+      
+       # The motors on the left side of the drive.
+        self.left1 = PWMSparkMax(constants.DriveConstants.kLeftMotor1Port)
+        self.left2 = PWMSparkMax(constants.DriveConstants.kLeftMotor2Port)
 
         # The motors on the right side of the drive.
-        self.rightMotors = wpilib.MotorControllerGroup(
-            wpilib.PWMSparkMax(constants.DriveConstants.kRightMotor1Port),
-            wpilib.PWMSparkMax(constants.DriveConstants.kRightMotor2Port),
-        )
+        self.right1 = PWMSparkMax(constants.DriveConstants.kRightMotor1Port)
+        self.right2 = PWMSparkMax(constants.DriveConstants.kRightMotor2Port)
+
+        self.left1.addFollower(self.left2)
+        self.right1.addFollower(self.right2)
 
         # The robot's drive
-        self.drive = wpilib.drive.DifferentialDrive(self.leftMotors, self.rightMotors)
+        self.drive = DifferentialDrive(self.left1, self.right1)
 
         # The left-side drive encoder
-        self.leftEncoder = wpilib.Encoder(
+        self.leftEncoder = Encoder(
             constants.DriveConstants.kLeftEncoderPorts[0],
             constants.DriveConstants.kLeftEncoderPorts[1],
             constants.DriveConstants.kLeftEncoderReversed,
         )
 
         # The right-side drive encoder
-        self.rightEncoder = wpilib.Encoder(
+        self.rightEncoder = Encoder(
             constants.DriveConstants.kRightEncoderPorts[0],
             constants.DriveConstants.kRightEncoderPorts[1],
             constants.DriveConstants.kRightEncoderReversed,
@@ -49,7 +49,7 @@ class DriveSubsystem(commands2.Subsystem):
         # We need to invert one side of the drivetrain so that positive voltages
         # result in both sides moving forward. Depending on how your robot's
         # gearbox is constructed, you might have to invert the left side instead.
-        self.rightMotors.setInverted(True)
+        self.right1.setInverted(True)
 
         # Sets the distance per pulse for the encoders
         self.leftEncoder.setDistancePerPulse(
@@ -59,7 +59,7 @@ class DriveSubsystem(commands2.Subsystem):
             constants.DriveConstants.kEncoderDistancePerPulse
         )
 
-        self.gyro = wpilib.ADXRS450_Gyro()
+        self.gyro = ADXRS450_Gyro()
 
     def arcadeDrive(self, fwd: float, rot: float):
         """
@@ -83,7 +83,7 @@ class DriveSubsystem(commands2.Subsystem):
         """
         return (self.leftEncoder.getDistance() + self.rightEncoder.getDistance()) / 2.0
 
-    def getLeftEncoder(self) -> wpilib.Encoder:
+    def getLeftEncoder(self) -> Encoder:
         """
         Gets the left drive encoder.
 
@@ -91,7 +91,7 @@ class DriveSubsystem(commands2.Subsystem):
         """
         return self.leftEncoder
 
-    def getRightEncoder(self) -> wpilib.Encoder:
+    def getRightEncoder(self) -> Encoder:
         """
         Gets the right drive encoder.
 

--- a/GyroDriveCommands/subsystems/drivesubsystem.py
+++ b/GyroDriveCommands/subsystems/drivesubsystem.py
@@ -17,7 +17,6 @@ class DriveSubsystem(commands2.Subsystem):
         """Creates a new DriveSubsystem"""
         super().__init__()
 
-      
         # The motors on the left side of the drive.
         self.left1 = PWMSparkMax(constants.DriveConstants.kLeftMotor1Port)
         self.left2 = PWMSparkMax(constants.DriveConstants.kLeftMotor2Port)

--- a/GyroDriveCommands/subsystems/drivesubsystem.py
+++ b/GyroDriveCommands/subsystems/drivesubsystem.py
@@ -18,7 +18,7 @@ class DriveSubsystem(commands2.Subsystem):
         super().__init__()
 
       
-       # The motors on the left side of the drive.
+        # The motors on the left side of the drive.
         self.left1 = PWMSparkMax(constants.DriveConstants.kLeftMotor1Port)
         self.left2 = PWMSparkMax(constants.DriveConstants.kLeftMotor2Port)
 

--- a/HatchbotInlined/subsystems/drivesubsystem.py
+++ b/HatchbotInlined/subsystems/drivesubsystem.py
@@ -29,10 +29,7 @@ class DriveSubsystem(commands2.Subsystem):
         self.right1.setInverted(True)
 
         # The robot's drive
-        self.drive = wpilib.drive.DifferentialDrive(
-            self.left1,
-            self.right1
-        )
+        self.drive = wpilib.drive.DifferentialDrive(self.left1, self.right1)
 
         # The left-side drive encoder
         self.leftEncoder = wpilib.Encoder(

--- a/HatchbotInlined/subsystems/drivesubsystem.py
+++ b/HatchbotInlined/subsystems/drivesubsystem.py
@@ -20,10 +20,18 @@ class DriveSubsystem(commands2.Subsystem):
         self.right1 = wpilib.PWMVictorSPX(constants.kRightMotor1Port)
         self.right2 = wpilib.PWMVictorSPX(constants.kRightMotor2Port)
 
+        self.left1.addFollower(self.left2)
+        self.right1.addFollower(self.right2)
+
+        # We need to invert one side of the drivetrain so that positive speeds
+        # result in both sides moving forward. Depending on how your robot's
+        # drivetrain is constructed, you might have to invert the left side instead.
+        self.right1.setInverted(True)
+
         # The robot's drive
         self.drive = wpilib.drive.DifferentialDrive(
-            wpilib.MotorControllerGroup(self.left1, self.left2),
-            wpilib.MotorControllerGroup(self.right1, self.right2),
+            self.left1,
+            self.right1
         )
 
         # The left-side drive encoder

--- a/HatchbotTraditional/subsystems/drivesubsystem.py
+++ b/HatchbotTraditional/subsystems/drivesubsystem.py
@@ -26,10 +26,7 @@ class DriveSubsystem(commands2.Subsystem):
         self.right1.setInverted(True)
 
         # The robot's drive
-        self.drive = wpilib.drive.DifferentialDrive(
-            self.left1,
-            self.right1
-        )
+        self.drive = wpilib.drive.DifferentialDrive(self.left1, self.right1)
 
         # The left-side drive encoder
         self.leftEncoder = wpilib.Encoder(

--- a/HatchbotTraditional/subsystems/drivesubsystem.py
+++ b/HatchbotTraditional/subsystems/drivesubsystem.py
@@ -20,10 +20,13 @@ class DriveSubsystem(commands2.Subsystem):
         self.right1 = wpilib.PWMVictorSPX(constants.kRightMotor1Port)
         self.right2 = wpilib.PWMVictorSPX(constants.kRightMotor2Port)
 
+        self.left1.addFollower(self.left2)
+        self.right1.addFollower(self.right2)
+
         # The robot's drive
         self.drive = wpilib.drive.DifferentialDrive(
-            wpilib.MotorControllerGroup(self.left1, self.left2),
-            wpilib.MotorControllerGroup(self.right1, self.right2),
+            self.left1,
+            self.right1,
         )
 
         # The left-side drive encoder

--- a/HatchbotTraditional/subsystems/drivesubsystem.py
+++ b/HatchbotTraditional/subsystems/drivesubsystem.py
@@ -20,13 +20,15 @@ class DriveSubsystem(commands2.Subsystem):
         self.right1 = wpilib.PWMVictorSPX(constants.kRightMotor1Port)
         self.right2 = wpilib.PWMVictorSPX(constants.kRightMotor2Port)
 
-        self.left1.addFollower(self.left2)
-        self.right1.addFollower(self.right2)
+        # We need to invert one side of the drivetrain so that positive speeds
+        # result in both sides moving forward. Depending on how your robot's
+        # drivetrain is constructed, you might have to invert the left side instead.
+        self.right1.setInverted(True)
 
         # The robot's drive
         self.drive = wpilib.drive.DifferentialDrive(
             self.left1,
-            self.right1,
+            self.right1
         )
 
         # The left-side drive encoder

--- a/RamseteCommand/subsystems/driveSubsystem.py
+++ b/RamseteCommand/subsystems/driveSubsystem.py
@@ -6,7 +6,7 @@
 
 from commands2 import Subsystem
 
-from wpilib import MotorControllerGroup, PWMSparkMax, Encoder, ADXRS450_Gyro
+from wpilib import PWMSparkMax, Encoder, ADXRS450_Gyro
 from wpilib.drive import DifferentialDrive
 
 from wpimath.kinematics import DifferentialDriveOdometry, DifferentialDriveWheelSpeeds
@@ -19,19 +19,23 @@ class DriveSubsystem(Subsystem):
         super().__init__()
 
         # The motors on the left side of the drive.
-        self.leftMotors = MotorControllerGroup(
-            PWMSparkMax(constants.kLeftMotor1Port),
-            PWMSparkMax(constants.kLeftMotor2Port),
-        )
+        self.left1 = PWMSparkMax(constants.kLeftMotor1Port)
+        self.left2 = PWMSparkMax(constants.kLeftMotor2Port)
 
         # The motors on the right side of the drive.
-        self.rightMotors = MotorControllerGroup(
-            PWMSparkMax(constants.kRightMotor1Port),
-            PWMSparkMax(constants.kRightMotor2Port),
-        )
+        self.right1 = PWMSparkMax(constants.kRightMotor1Port)
+        self.right2 = PWMSparkMax(constants.kRightMotor2Port)
+
+        self.left1.addFollower(self.left2)
+        self.right1.addFollower(self.right2)
 
         # The robot's drive
-        self.drive = DifferentialDrive(self.leftMotors, self.rightMotors)
+        self.drive = DifferentialDrive(self.left1, self.right1)
+
+        # We need to invert one side of the drivetrain so that positive voltages
+        # result in both sides moving forward. Depending on how your robot's
+        # gearbox is constructed, you might have to invert the left side instead.
+        self.right1.setInverted(True)
 
         # The left-side drive encoder
         self.leftEncoder = Encoder(
@@ -50,10 +54,7 @@ class DriveSubsystem(Subsystem):
         # The gyro sensor
         self.gyro = ADXRS450_Gyro()
 
-        # We need to invert one side of the drivetrain so that positive voltages
-        # result in both sides moving forward. Depending on how your robot's
-        # gearbox is constructed, you might have to invert the left side instead.
-        self.rightMotors.setInverted(True)
+        
 
         # Sets the distance per pulse for the encoders
         self.leftEncoder.setDistancePerPulse(constants.kEncoderDistancePerPulse)
@@ -101,8 +102,8 @@ class DriveSubsystem(Subsystem):
 
     def tankDriveVolts(self, leftVolts, rightVolts):
         """Controls the left and right sides of the drive directly with voltages."""
-        self.leftMotors.setVoltage(leftVolts)
-        self.rightMotors.setVoltage(rightVolts)
+        self.left1.setVoltage(leftVolts)
+        self.right1.setVoltage(rightVolts)
         self.drive.feed()
 
     def resetEncoders(self):

--- a/RamseteCommand/subsystems/driveSubsystem.py
+++ b/RamseteCommand/subsystems/driveSubsystem.py
@@ -54,8 +54,6 @@ class DriveSubsystem(Subsystem):
         # The gyro sensor
         self.gyro = ADXRS450_Gyro()
 
-        
-
         # Sets the distance per pulse for the encoders
         self.leftEncoder.setDistancePerPulse(constants.kEncoderDistancePerPulse)
         self.rightEncoder.setDistancePerPulse(constants.kEncoderDistancePerPulse)

--- a/RamseteController/drivetrain.py
+++ b/RamseteController/drivetrain.py
@@ -24,16 +24,16 @@ class Drivetrain:
     kEncoderResolution = 4096  # counts per revolution
 
     def __init__(self):
-        leftLeader = wpilib.PWMSparkMax(1)
-        leftFollower = wpilib.PWMSparkMax(2)
-        rightLeader = wpilib.PWMSparkMax(3)
-        rightFollower = wpilib.PWMSparkMax(4)
+        self.leftLeader = wpilib.PWMSparkMax(1)
+        self.leftFollower = wpilib.PWMSparkMax(2)
+        self.rightLeader = wpilib.PWMSparkMax(3)
+        self.rightFollower = wpilib.PWMSparkMax(4)
 
         self.leftEncoder = wpilib.Encoder(0, 1)
         self.rightEncoder = wpilib.Encoder(2, 3)
 
-        self.leftGroup = wpilib.MotorControllerGroup(leftLeader, leftFollower)
-        self.rightGroup = wpilib.MotorControllerGroup(rightLeader, rightFollower)
+        self.leftLeader.addFollower(self.leftFollower)
+        self.rightLeader.addFollower(self.rightFollower)
 
         self.gyro = wpilib.AnalogGyro(0)
 
@@ -52,7 +52,7 @@ class Drivetrain:
         # We need to invert one side of the drivetrain so that positive voltages
         # result in both sides moving forward. Depending on how your robot's
         # gearbox is constructed, you might have to invert the left side instead.
-        self.rightGroup.setInverted(True)
+        self.rightLeader.setInverted(True)
 
         # Set the distance per pulse for the drive encoders. We can simply use the
         # distance traveled for one rotation of the wheel divided by the encoder
@@ -85,8 +85,8 @@ class Drivetrain:
             self.rightEncoder.getRate(), speeds.right
         )
 
-        self.leftGroup.setVoltage(leftOutput + leftFeedforward)
-        self.rightGroup.setVoltage(rightOutput + rightFeedforward)
+        self.leftLeader.setVoltage(leftOutput + leftFeedforward)
+        self.rightLeader.setVoltage(rightOutput + rightFeedforward)
 
     def drive(self, xSpeed, rot):
         """Drives the robot with the given linear velocity and angular velocity."""


### PR DESCRIPTION
Based on https://github.com/wpilibsuite/allwpilib/pull/6053, I updated the following examples:
- Armbot
- ArmBotOffboard
- DifferentialDriveBot
- GyroDriveCommands
- FrisbeeBot
- HatchbotInlined
- HatchbotTraditional
- RamseteCommand
- RamseteController

These are all of the available examples from said PR that could be updated

Please let me know if you would like any changes.
